### PR TITLE
Add browserify config to fix dependent builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,12 @@
     "lodash.defaults": "~4.0.1",
     "lodash.defaultsdeep": "~4.3.4",
     "lodash.pickby": "~4.3.0"
+  },
+  "browserify": {
+    "transform": [
+      [
+        "babelify"
+      ]
+    ]
   }
 }


### PR DESCRIPTION
Browserify needs to know to use babelify when bundling the package. Babelify doesn't need to be a dependency of stipulate though.
