### PR TITLE
Refactor Array#includes usage due to lack of support

### DIFF
--- a/src/enforce-ok.js
+++ b/src/enforce-ok.js
@@ -4,7 +4,7 @@ function makeOkCheck({ okCodes = [], test } = {}) {
       return response;
     }
 
-    const codeOk = okCodes.includes(response.status);
+    const codeOk = okCodes.indexOf(response.status) >= 0;
 
     if(!test && (response.ok || codeOk)) {
       return response;


### PR DESCRIPTION
This refactors a line that uses `Array.prototype.includes`.

Stipulate uses `babel-node` for testing. `babel-node` supports `Array.prototype.includes`, but `babel-preset-es2015` doesn't. As a result, Stipulate's tests pass, but Stipulate breaks when it's bundled and ran in Node and MS browsers.  Instead of adding another Babel transform or polyfill, I choose to just refactor the line.

@yola/frontend-engineering 
