### PR TITLE
Use lodash to help de-dup a consumer's build

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,7 @@
     ]
   },
   "dependencies": {
-    "lodash.defaults": "~4.1.0",
-    "lodash.defaultsdeep": "~4.5.0",
-    "lodash.pickby": "~4.5.0"
+    "lodash": "4.x"
   },
   "browserify": {
     "transform": [

--- a/src/build-options.js
+++ b/src/build-options.js
@@ -1,11 +1,10 @@
-import defaultsDeep from 'lodash.defaultsdeep';
-import pickBy from 'lodash.pickby';
+import _ from 'lodash';
 
 const buildOptions = function(priority, defaults) {
-  const options = defaultsDeep({}, priority, defaults);
+  const options = _.defaultsDeep({}, priority, defaults);
 
   if(options.headers) {
-    options.headers = pickBy(options.headers, (value) => value);
+    options.headers = _.pickBy(options.headers, (value) => value);
   }
 
   if(priority && priority.okCodes) {

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -1,12 +1,11 @@
-import defaults from 'lodash.defaults';
-import pickBy from 'lodash.pickby';
+import _ from 'lodash';
 import url from 'url';
 
 const resolveUrl = function(urlString, query) {
   const parsedUrl = url.parse(urlString, true);
 
-  const mergedQuery = defaults({}, query, parsedUrl.query);
-  const fullQuery = pickBy(mergedQuery, (value) => value);
+  const mergedQuery = _.defaults({}, query, parsedUrl.query);
+  const fullQuery = _.pickBy(mergedQuery, (value) => value);
 
   delete parsedUrl.search;
   parsedUrl.query = fullQuery;


### PR DESCRIPTION
As is, cherry-picking lodash tools is hurting the application
build size. Build tools are not able to recognize that `lodash.<util>` is
a member of `lodash`.

The end result is a duplicate bundling of lodash members.

Consolidating all clients on `lodash@4` should eliminate the duplication.