### PR TITLE
replace prepublish with prepare hook

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-prefix = "~"
+package-lock = false

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "compile-cjs": "scripts/compile-common-js.sh",
     "coveralls": "cat coverage/lcov.info | node_modules/.bin/coveralls",
-    "prepublish": "npm run compile-cjs",
+    "prepare": "npm run compile-cjs",
     "test": "babel-node node_modules/.bin/isparta cover --root src/ --report text --report lcov --report html node_modules/.bin/_mocha --"
   },
   "repository": {


### PR DESCRIPTION
In scope of: https://github.com/yola/ws-headless-builder/issues/41

In order to enable compatibility with npm@4.x