### PR TITLE
Replace `url` node module usage with url-join & URLSearchParams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 package
 package-lock.json
 stipulate-*.tgz
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Replace `url` node module usage with `url-join` & `URLSearchParams`
+
 ## 0.1.0
 
 - Package CommonJS compatible code

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stipulate",
-  "version": "0.2.0",
+  "version": "0.2.0-raffa-rc.1",
   "description": "A module extending the Fetch API with some useful default error handling and hooks.",
   "main": "cjs/stipulate.js",
   "module": "src/stipulate.js",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "lodash": "4.x",
-    "url-join": "~5.0.0"
+    "url-join": "^4.0.1"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stipulate",
-  "version": "0.2.0-raffa-rc.2",
+  "version": "0.2.0",
   "description": "A module extending the Fetch API with some useful default error handling and hooks.",
   "main": "cjs/stipulate.js",
   "module": "src/stipulate.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stipulate",
-  "version": "0.2.0-raffa-rc.1",
+  "version": "0.2.0-raffa-rc.2",
   "description": "A module extending the Fetch API with some useful default error handling and hooks.",
   "main": "cjs/stipulate.js",
   "module": "src/stipulate.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stipulate",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A module extending the Fetch API with some useful default error handling and hooks.",
   "main": "cjs/stipulate.js",
   "module": "src/stipulate.js",
@@ -37,7 +37,8 @@
     "mocha": "~2.5.3"
   },
   "dependencies": {
-    "lodash": "4.x"
+    "lodash": "4.x",
+    "url-join": "~5.0.0"
   },
   "browserify": {
     "transform": [

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -2,16 +2,29 @@ import _ from 'lodash';
 import urlJoin from 'url-join';
 
 const resolveUrl = function(urlString, query) {
-  const parselUrlQuery = Object.fromEntries(
-      new URLSearchParams(urlString)
-  );
+  let parsedUrlQuery = {};
+  let urlWithoutParams = urlString;
+  const hasParams = urlString.includes('?');
 
-  const mergedQuery = _.defaults({}, query, parselUrlQuery);
+  if (hasParams){
+    const urlSplit = urlString.split('?');
+    parsedUrlQuery = Object.fromEntries(
+        new URLSearchParams(urlSplit[1])
+    );
+    urlWithoutParams = urlSplit[0];
+  }
+
+  const mergedQuery = _.defaults({}, query, parsedUrlQuery);
   const fullQuery = _.pickBy(mergedQuery, (value) => value);
 
   const searchParams = new URLSearchParams(fullQuery);
+  const searchParamsString = searchParams.toString();
 
-  return urlJoin(urlString, `?${searchParams.toString()}`);
+  if (searchParamsString){
+    return urlJoin(urlWithoutParams, `?${searchParamsString}`);
+  }
+
+  return urlWithoutParams;
 };
 
 export default resolveUrl;

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -4,14 +4,14 @@ import urlJoin from 'url-join';
 const resolveUrl = function(urlString, query) {
   let parsedUrlQuery = {};
   let urlWithoutParams = urlString;
-  const hasParams = urlString.includes('?');
+  const queryStart = urlString.lastIndexOf('?');
 
-  if (hasParams){
-    const urlSplit = urlString.split('?');
+  if (queryStart !== -1){
+    const paramStr = urlString.slice(queryStart);
     parsedUrlQuery = Object.fromEntries(
-        new URLSearchParams(urlSplit[1])
+        new URLSearchParams(paramStr)
     );
-    urlWithoutParams = urlSplit[0];
+    urlWithoutParams = urlString.slice(0, queryStart);
   }
 
   const mergedQuery = _.defaults({}, query, parsedUrlQuery);

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -1,16 +1,17 @@
 import _ from 'lodash';
-import url from 'url';
+import urlJoin from 'url-join';
 
 const resolveUrl = function(urlString, query) {
-  const parsedUrl = url.parse(urlString, true);
+  const parselUrlQuery = Object.fromEntries(
+      new URLSearchParams(urlString)
+  );
 
-  const mergedQuery = _.defaults({}, query, parsedUrl.query);
+  const mergedQuery = _.defaults({}, query, parselUrlQuery);
   const fullQuery = _.pickBy(mergedQuery, (value) => value);
 
-  delete parsedUrl.search;
-  parsedUrl.query = fullQuery;
+  const searchParams = new URLSearchParams(fullQuery);
 
-  return url.format(parsedUrl);
+  return urlJoin(urlString, `?${searchParams.toString()}`);
 };
 
 export default resolveUrl;


### PR DESCRIPTION
We need to replace `url` node module usage to use webpack 5 without any node modules polyfills