### PR TITLE
[YD-1783] Update `lodash` version to `4.18.1` to fix security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## dev
+
+- Bump up `lodash` version to `4.18.1` to fix security vulnerability
+
 ## 0.2.1
 
 - Update lodash dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## dev
+## 0.3.0
 
 - Bump up `lodash` version to `4.18.1` to fix security vulnerability
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stipulate",
-  "version": "0.2.2-rc.ch.1",
+  "version": "0.3.0",
   "description": "A module extending the Fetch API with some useful default error handling and hooks.",
   "main": "cjs/stipulate.js",
   "module": "src/stipulate.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stipulate",
-  "version": "0.2.1",
+  "version": "0.2.2-rc.ch.1",
   "description": "A module extending the Fetch API with some useful default error handling and hooks.",
   "main": "cjs/stipulate.js",
   "module": "src/stipulate.js",
@@ -37,7 +37,7 @@
     "mocha": "~2.5.3"
   },
   "dependencies": {
-    "lodash": ">=4.17.21",
+    "lodash": ">=4.18.1",
     "url-join": "^4.0.1"
   },
   "browserify": {


### PR DESCRIPTION
Part of: https://hostway.atlassian.net/browse/YD-1783